### PR TITLE
New datasource: oVirt datacenters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+

--- a/main.tf
+++ b/main.tf
@@ -1,41 +1,45 @@
+variable "ovirt_username" {}
+variable "ovirt_url" {}
 variable "ovirt_pass" {}
 
 provider "ovirt" {
-  username = "kschmidt@PNL.GOV"
-  url = "https://ovirt.emsl.pnl.gov/ovirt-engine/api"
+  username = "${var.ovirt_username}"
+  url      = "${var.ovirt_url}"
   password = "${var.ovirt_pass}"
 }
 
-resource "ovirt_vm" "my_vm" {
-  name = "my_first_vm"
-  cluster = "Default"
+resource "ovirt_vm" "joey_vm_1" {
+  name               = "joey_vm_1"
+  cluster            = "Default"
   authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
+
   network_interface {
-    label = "eth0"
-    boot_proto = "static"
-    ip_address = "130.20.232.184"
-    gateway = "130.20.232.1"
+    label       = "eth0"
+    boot_proto  = "static"
+    ip_address  = "130.20.232.184"
+    gateway     = "130.20.232.1"
     subnet_mask = "255.255.255.0"
   }
 
   attached_disks = [{
-    disk_id = "${ovirt_disk.my_disk.id}"
-    bootable = "false"
-    interface  = "virtio"
+    disk_id   = "${ovirt_disk.joey_disk_1.id}"
+    bootable  = "false"
+    interface = "virtio"
   }]
 
-  template = "centos-7.4.1707-cloudinit-mgmt"
+  template = "Blank"
+
   provisioner "remote-exec" {
     inline = [
-      "uptime"
+      "uptime",
     ]
   }
 }
 
-resource "ovirt_disk" "my_disk" {
-  name = "my_first_disk"
-  size = 1024
-  format = "cow"
-  storage_domain_id = "dfe8e7be-e495-49a7-be2d-71aba891ceb4"
-  sparse = true
+resource "ovirt_disk" "joey_disk_1" {
+  name              = "joey_disk_1"
+  size              = 33687091200
+  format            = "cow"
+  storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
+  sparse            = true
 }

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,13 @@ resource "ovirt_vm" "my_vm_1" {
   cluster            = "Default"
   authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 
+  boot_disk = {
+    disk_id      = "${ovirt_disk.my_boot_disk_2.id}"
+    interface    = "virtio"
+    active       = true
+    logical_name = "/dev/sda"
+  }
+
   network_interface {
     label       = "eth0"
     boot_proto  = "static"
@@ -22,6 +29,15 @@ resource "ovirt_vm" "my_vm_1" {
   }
 
   template = "Blank"
+}
+
+resource "ovirt_disk" "my_boot_disk_2" {
+  name              = "my_boot_disk_2"
+  alias             = "my_boot_disk_2"
+  size              = 23687091200
+  format            = "cow"
+  storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
+  sparse            = true
 }
 
 resource "ovirt_disk" "my_disk_1" {
@@ -36,8 +52,16 @@ resource "ovirt_disk" "my_disk_1" {
 resource "ovirt_disk_attachment" "my_diskattachment_1" {
   disk_id   = "${ovirt_disk.my_disk_1.id}"
   vm_id     = "${ovirt_vm.my_vm_1.id}"
-  bootable  = "false"
+  bootable  = false
   interface = "virtio"
+}
+
+data "ovirt_datacenters" "defaultDC" {
+  name = "Default"
+}
+
+output "default_dc_id" {
+  value = "${data.ovirt_datacenters.defaultDC.datacenters.0.id}"
 }
 
 output "disk_id" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
-variable "ovirt_username" {}
 variable "ovirt_url" {}
+variable "ovirt_username" {}
 variable "ovirt_pass" {}
 
 provider "ovirt" {
@@ -21,19 +21,7 @@ resource "ovirt_vm" "joey_vm_1" {
     subnet_mask = "255.255.255.0"
   }
 
-  attached_disks = [{
-    disk_id   = "${ovirt_disk.joey_disk_1.id}"
-    bootable  = "false"
-    interface = "virtio"
-  }]
-
   template = "Blank"
-
-  provisioner "remote-exec" {
-    inline = [
-      "uptime",
-    ]
-  }
 }
 
 resource "ovirt_disk" "joey_disk_1" {
@@ -42,4 +30,23 @@ resource "ovirt_disk" "joey_disk_1" {
   format            = "cow"
   storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
   sparse            = true
+}
+
+resource "ovirt_disk_attachment" "joey_diskattachment_1" {
+  disk_id   = "${ovirt_disk.joey_disk_1.id}"
+  vm_id     = "${ovirt_vm.joey_vm_1.id}"
+  bootable  = "false"
+  interface = "virtio"
+}
+
+output "disk_id" {
+  value = "${ovirt_disk.joey_disk_1.id}"
+}
+
+output "diskattachment_id" {
+  value = "${ovirt_disk_attachment.joey_diskattachment_1.id}"
+}
+
+output "vm_id" {
+  value = "${ovirt_vm.joey_vm_1.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,8 @@ provider "ovirt" {
   password = "${var.ovirt_pass}"
 }
 
-resource "ovirt_vm" "joey_vm_1" {
-  name               = "joey_vm_1"
+resource "ovirt_vm" "my_vm_1" {
+  name               = "my_vm_1"
   cluster            = "Default"
   authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
 
@@ -24,29 +24,30 @@ resource "ovirt_vm" "joey_vm_1" {
   template = "Blank"
 }
 
-resource "ovirt_disk" "joey_disk_1" {
-  name              = "joey_disk_1"
-  size              = 33687091200
+resource "ovirt_disk" "my_disk_1" {
+  name              = "my_disk_1"
+  alias             = "my_disk_1"
+  size              = 23687091200
   format            = "cow"
   storage_domain_id = "cadbe661-0e35-4fcb-a70d-2b17e2559d9c"
   sparse            = true
 }
 
-resource "ovirt_disk_attachment" "joey_diskattachment_1" {
-  disk_id   = "${ovirt_disk.joey_disk_1.id}"
-  vm_id     = "${ovirt_vm.joey_vm_1.id}"
+resource "ovirt_disk_attachment" "my_diskattachment_1" {
+  disk_id   = "${ovirt_disk.my_disk_1.id}"
+  vm_id     = "${ovirt_vm.my_vm_1.id}"
   bootable  = "false"
   interface = "virtio"
 }
 
 output "disk_id" {
-  value = "${ovirt_disk.joey_disk_1.id}"
+  value = "${ovirt_disk.my_disk_1.id}"
 }
 
 output "diskattachment_id" {
-  value = "${ovirt_disk_attachment.joey_diskattachment_1.id}"
+  value = "${ovirt_disk_attachment.my_diskattachment_1.id}"
 }
 
 output "vm_id" {
-  value = "${ovirt_vm.joey_vm_1.id}"
+  value = "${ovirt_vm.my_vm_1.id}"
 }

--- a/ovirt/data_source_datacenters.go
+++ b/ovirt/data_source_datacenters.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func dataSourceOvirtDataCenters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtDataCentersRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// Computed
+			"datacenters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"local": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"quota_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtDataCentersRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	dcsResp, err := conn.SystemService().DataCentersService().
+		List().
+		Search(fmt.Sprintf("name=%s", d.Get("name").(string))).
+		Send()
+	if err != nil {
+		return err
+	}
+	dcs, ok := dcsResp.DataCenters()
+	if !ok || len(dcs.Slice()) == 0 {
+		return fmt.Errorf("your query datacenter returned no results, please change your search criteria and try again")
+	}
+
+	return dataCentersDecriptionAttributes(d, dcs.Slice(), meta)
+}
+
+func dataCentersDecriptionAttributes(d *schema.ResourceData, dcs []*ovirtsdk4.DataCenter, meta interface{}) error {
+	var s []map[string]interface{}
+	for _, v := range dcs {
+		mapping := map[string]interface{}{
+			"id":         v.MustId(),
+			"status":     v.MustStatus(),
+			"local":      v.MustLocal(),
+			"quota_mode": v.MustQuotaMode(),
+		}
+		s = append(s, mapping)
+	}
+	d.SetId(resource.UniqueId())
+	if err := d.Set("datacenters", s); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -7,9 +7,9 @@
 package ovirt
 
 import (
-	"github.com/EMSL-MSC/ovirtapi"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 // Provider returns oVirt provider configuration
@@ -45,5 +45,10 @@ func Provider() terraform.ResourceProvider {
 }
 
 func ConfigureProvider(d *schema.ResourceData) (interface{}, error) {
-	return ovirtapi.NewConnection(d.Get("url").(string), d.Get("username").(string), d.Get("password").(string), false)
+	return ovirtsdk4.NewConnectionBuilder().
+		URL(d.Get("url").(string)).
+		Username(d.Get("username").(string)).
+		Password(d.Get("password").(string)).
+		Insecure(true).
+		Build()
 }

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -40,7 +40,8 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_disk_attachment": resourceDiskAttachment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"ovirt_disk": dataSourceDisk(),
+			"ovirt_disk":        dataSourceDisk(),
+			"ovirt_datacenters": dataSourceOvirtDataCenters(),
 		},
 	}
 }

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -35,8 +35,9 @@ func Provider() terraform.ResourceProvider {
 		},
 		ConfigureFunc: ConfigureProvider,
 		ResourcesMap: map[string]*schema.Resource{
-			"ovirt_vm":   resourceVM(),
-			"ovirt_disk": resourceDisk(),
+			"ovirt_vm":              resourceVM(),
+			"ovirt_disk":            resourceDisk(),
+			"ovirt_disk_attachment": resourceDiskAttachment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ovirt_disk": dataSourceDisk(),

--- a/ovirt/resource_disk.go
+++ b/ovirt/resource_disk.go
@@ -15,12 +15,12 @@ func resourceDisk() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDiskCreate,
 		Read:   resourceDiskRead,
+		Update: resourceDiskUpdate,
 		Delete: resourceDiskDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"format": {
 				Type:     schema.TypeString,
@@ -35,7 +35,6 @@ func resourceDisk() *schema.Resource {
 			"size": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"shareable": {
 				Type:     schema.TypeBool,
@@ -80,6 +79,10 @@ func resourceDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(addResp.MustDisk().MustId())
+	return resourceDiskRead(d, meta)
+}
+
+func resourceDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 

--- a/ovirt/resource_disk_attachment.go
+++ b/ovirt/resource_disk_attachment.go
@@ -26,10 +26,12 @@ func resourceDiskAttachment() *schema.Resource {
 			"vm_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"disk_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"active": &schema.Schema{
 				Type:     schema.TypeBool,

--- a/ovirt/resource_disk_attachment.go
+++ b/ovirt/resource_disk_attachment.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2017 Battelle Memorial Institute
+// All rights reserved.
+//
+// This software may be modified and distributed under the terms
+// of the BSD-2 license.  See the LICENSE file for details.
+
+package ovirt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
+)
+
+func resourceDiskAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDiskAttachmentCreate,
+		Read:   resourceDiskAttachmentRead,
+		Update: resourceDiskAttachmentUpdate,
+		Delete: resourceDiskAttachmentDelete,
+		Schema: map[string]*schema.Schema{
+			"vm_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"disk_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"active": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"bootable": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logical_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pass_discard": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"read_only": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"use_scsi_reservation": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceDiskAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	diskID := d.Get("disk_id").(string)
+	diskService := conn.SystemService().DisksService().DiskService(diskID)
+
+	var disk *ovirtsdk4.Disk
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		getDiskResp, err := diskService.Get().Send()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		disk = getDiskResp.MustDisk()
+
+		if disk.MustStatus() == ovirtsdk4.DISKSTATUS_LOCKED {
+			return resource.RetryableError(fmt.Errorf("disk is locked, wait for next check"))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	attachmentBuilder := ovirtsdk4.NewDiskAttachmentBuilder().
+		Disk(disk).
+		Interface(ovirtsdk4.DiskInterface(d.Get("interface").(string))).
+		Bootable(d.Get("bootable").(bool)).
+		Active(d.Get("active").(bool)).
+		ReadOnly(d.Get("read_only").(bool)).
+		UsesScsiReservation(d.Get("use_scsi_reservation").(bool))
+	if logicalName, ok := d.GetOk("logical_name"); ok {
+		attachmentBuilder.LogicalName(logicalName.(string))
+	}
+	if passDiscard, ok := d.GetOkExists("pass_discard"); ok {
+		attachmentBuilder.PassDiscard(passDiscard.(bool))
+	}
+	attachment, err := attachmentBuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	vmID := d.Get("vm_id").(string)
+	addAttachmentResp, err := conn.SystemService().
+		VmsService().
+		VmService(vmID).
+		DiskAttachmentsService().
+		Add().
+		Attachment(attachment).
+		Send()
+	if err != nil {
+		return err
+	}
+
+	_, ok := addAttachmentResp.Attachment()
+	if ok {
+		d.SetId(vmID + ":" + diskID)
+	}
+
+	return resourceDiskAttachmentRead(d, meta)
+}
+
+func resourceDiskAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceDiskAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+	// Disk ID is equals to its relevant Disk Attachment ID
+	// Sess: https://github.com/oVirt/ovirt-engine/blob/68753f46f09419ddcdbb632453501273697d1a20/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DiskAttachmentMapper.java
+	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	if err != nil {
+		return err
+	}
+	d.Set("vm_id", vmID)
+	d.Set("disk_id", diskID)
+
+	attachmentService := conn.SystemService().
+		VmsService().
+		VmService(vmID).
+		DiskAttachmentsService().AttachmentService(diskID)
+	attachmentResp, err := attachmentService.Get().Send()
+	if err != nil {
+		return err
+	}
+	attachment, ok := attachmentResp.Attachment()
+	if !ok {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("active", attachment.MustActive())
+	d.Set("bootable", attachment.MustBootable())
+	d.Set("interface", attachment.MustInterface())
+	d.Set("read_only", attachment.MustReadOnly())
+	d.Set("use_scsi_reservation", attachment.MustUsesScsiReservation())
+	if logicalName, ok := attachment.LogicalName(); ok {
+		d.Set("logical_name", logicalName)
+	}
+	if passDiscard, ok := attachment.PassDiscard(); ok {
+		d.Set("pass_discard", passDiscard)
+	}
+
+	return nil
+}
+
+func resourceDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	if err != nil {
+		return err
+	}
+
+	vmService := conn.SystemService().VmsService().VmService(vmID)
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		vmGetResp, err := vmService.Get().Send()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		if vmGetResp.MustVm().MustStatus() != ovirtsdk4.VMSTATUS_DOWN {
+			return resource.RetryableError(fmt.Errorf("The VM attached to is not down"))
+		}
+		return nil
+	})
+
+	_, err = vmService.
+		DiskAttachmentsService().
+		AttachmentService(diskID).
+		Remove().
+		Send()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getVMIDAndDiskID(d *schema.ResourceData, meta interface{}) (string, string, error) {
+	parts := strings.Split(d.Id(), ":")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Invalid resource id")
+	}
+	return parts[0], parts[1], nil
+}

--- a/ovirt/resource_vm.go
+++ b/ovirt/resource_vm.go
@@ -8,11 +8,11 @@ package ovirt
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
-	"github.com/EMSL-MSC/ovirtapi"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	ovirtsdk4 "gopkg.in/imjoey/go-ovirt.v4"
 )
 
 func resourceVM() *schema.Resource {
@@ -144,138 +144,202 @@ func resourceVM() *schema.Resource {
 }
 
 func resourceVMCreate(d *schema.ResourceData, meta interface{}) error {
-	con := meta.(*ovirtapi.Connection)
-	newVM := con.NewVM()
-	newVM.Name = d.Get("name").(string)
+	conn := meta.(*ovirtsdk4.Connection)
+	vmsService := conn.SystemService().VmsService()
 
-	cluster := con.NewCluster()
-	cluster.Name = d.Get("cluster").(string)
-	newVM.Cluster = cluster
-
-	template := con.NewTemplate()
-	template.Name = d.Get("template").(string)
-	newVM.Template = template
-	newVM.CPU = &ovirtapi.CPU{
-		Topology: &ovirtapi.CPUTopology{
-			Cores:   d.Get("cores").(int),
-			Sockets: d.Get("sockets").(int),
-			Threads: d.Get("threads").(int),
-		},
-	}
-	newVM.Initialization = &ovirtapi.Initialization{}
-
-	newVM.Initialization.AuthorizedSSHKeys = d.Get("authorized_ssh_key").(string)
-
-	numNetworks := d.Get("network_interface.#").(int)
-	NICConfigurations := make([]ovirtapi.NICConfiguration, numNetworks)
-	for i := 0; i < numNetworks; i++ {
-		prefix := fmt.Sprintf("network_interface.%d", i)
-		_ = prefix
-		NICConfigurations[i] = ovirtapi.NICConfiguration{
-			IP: &ovirtapi.IP{
-				Address: d.Get(prefix + ".ip_address").(string),
-				Netmask: d.Get(prefix + ".subnet_mask").(string),
-				Gateway: d.Get(prefix + ".gateway").(string),
-			},
-			BootProtocol: d.Get(prefix + ".boot_proto").(string),
-			OnBoot:       strconv.FormatBool(d.Get(prefix + ".on_boot").(bool)),
-			Name:         d.Get(prefix + ".label").(string),
-		}
-		if i == 0 {
-			d.SetConnInfo(map[string]string{
-				"host": d.Get(prefix + ".ip_address").(string),
-			})
-		}
-	}
-	newVM.Initialization.NICConfigurations = &ovirtapi.NICConfigurations{NICConfiguration: NICConfigurations}
-
-	err := newVM.Save()
+	cluster, err := ovirtsdk4.NewClusterBuilder().
+		Name(d.Get("cluster").(string)).Build()
 	if err != nil {
 		return err
 	}
-	d.SetId(newVM.ID)
 
-	for newVM.Status != "down" {
-		time.Sleep(time.Second)
-		newVM.Update()
+	cpuCore, err := ovirtsdk4.NewCoreBuilder().
+		Socket(int64(d.Get("sockets").(int))).Build()
+	if err != nil {
+		return err
 	}
+
+	template, err := ovirtsdk4.NewTemplateBuilder().
+		Name(d.Get("template").(string)).Build()
+	if err != nil {
+		return err
+	}
+
+	cpu, err := ovirtsdk4.NewCpuBuilder().
+		CoresOfAny(cpuCore).Build()
+	if err != nil {
+		return err
+	}
+
+	initialBuilder := ovirtsdk4.NewInitializationBuilder().
+		AuthorizedSshKeys(d.Get("authorized_ssh_key").(string))
+
+	numNetworks := d.Get("network_interface.#").(int)
+	for i := 0; i < numNetworks; i++ {
+		prefix := fmt.Sprintf("network_interface.%d", i)
+
+		ncBuilder := ovirtsdk4.NewNicConfigurationBuilder().
+			Name(d.Get(prefix + ".label").(string)).
+			IpBuilder(
+				ovirtsdk4.NewIpBuilder().
+					Address(d.Get(prefix + ".ip_address").(string)).
+					Netmask(d.Get(prefix + ".subnet_mask").(string)).
+					Gateway(d.Get(prefix + ".gateway").(string))).
+			BootProtocol(ovirtsdk4.BootProtocol(d.Get(prefix + ".boot_proto").(string))).
+			OnBoot(d.Get(prefix + ".on_boot").(bool))
+		initialBuilder.NicConfigurationsBuilderOfAny(*ncBuilder)
+	}
+
+	initialize, err := initialBuilder.Build()
+	if err != nil {
+		return err
+	}
+
+	resp, err := vmsService.Add().
+		Vm(
+			ovirtsdk4.NewVmBuilder().
+				Name(d.Get("name").(string)).
+				Cluster(cluster).
+				Template(template).
+				Cpu(cpu).
+				Initialization(initialize).
+				MustBuild()).
+		Send()
+
+	if err != nil {
+		return err
+	}
+	newVM, ok := resp.Vm()
+	if ok {
+		d.SetId(newVM.MustId())
+	}
+
+	vmService := conn.SystemService().VmsService().VmService(newVM.MustId())
 
 	attachmentSet := d.Get("attached_disks").(*schema.Set)
 	for _, v := range attachmentSet.List() {
 		attachment := v.(map[string]interface{})
-		disk, err := con.GetDisk(attachment["disk_id"].(string))
+
+		diskService := conn.SystemService().DisksService().
+			DiskService(attachment["disk_id"].(string))
+
+		var disk *ovirtsdk4.Disk
+
+		err = resource.Retry(30*time.Second, func() *resource.RetryError {
+			getDiskResp, err := diskService.Get().Send()
+			if err != nil {
+				return resource.RetryableError(err)
+			}
+			disk = getDiskResp.MustDisk()
+
+			if disk.MustStatus() == ovirtsdk4.DISKSTATUS_LOCKED {
+				return resource.RetryableError(fmt.Errorf("disk is locked, wait for next check"))
+			}
+			return nil
+		})
+
 		if err != nil {
 			return err
 		}
-		diskAttachment := ovirtapi.DiskAttachment{
-			Disk:                disk,
-			Active:              strconv.FormatBool(attachment["active"].(bool)),
-			Bootable:            strconv.FormatBool(attachment["bootable"].(bool)),
-			Interface:           attachment["interface"].(string),
-			LogicalName:         attachment["logical_name"].(string),
-			PassDiscard:         strconv.FormatBool(attachment["pass_discard"].(bool)),
-			ReadOnly:            strconv.FormatBool(attachment["read_only"].(bool)),
-			UsesSCSIReservation: strconv.FormatBool(attachment["use_scsi_reservation"].(bool)),
-		}
-		_, err = newVM.AddLinkObject("diskattachments", diskAttachment, nil)
+
+		_, err = vmService.DiskAttachmentsService().Add().
+			Attachment(
+				ovirtsdk4.NewDiskAttachmentBuilder().
+					Disk(disk).
+					Interface(ovirtsdk4.DiskInterface(attachment["interface"].(string))).
+					Bootable(attachment["bootable"].(bool)).
+					Active(attachment["active"].(bool)).
+					LogicalName(attachment["logical_name"].(string)).
+					PassDiscard(attachment["pass_discard"].(bool)).
+					ReadOnly(attachment["read_only"].(bool)).
+					UsesScsiReservation(attachment["use_scsi_reservation"].(bool)).
+					MustBuild()).
+			Send()
 		if err != nil {
 			return err
 		}
+
 	}
 
-	err = newVM.Start("", "", "", "true", "", nil)
+	_, err = vmService.Start().Send()
 	if err != nil {
-		newVM.Delete()
 		return err
 	}
+
 	return nil
 }
 
 func resourceVMUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
+
 func resourceVMRead(d *schema.ResourceData, meta interface{}) error {
-	con := meta.(*ovirtapi.Connection)
-	vm, err := con.GetVM(d.Id())
+	conn := meta.(*ovirtsdk4.Connection)
 
+	getVmresp, err := conn.SystemService().VmsService().
+		VmService(d.Id()).Get().Send()
 	if err != nil {
+		return err
+	}
+
+	vm, ok := getVmresp.Vm()
+
+	if !ok {
 		d.SetId("")
 		return nil
 	}
-	d.Set("name", vm.Name)
+	d.Set("name", vm.MustName())
+	d.Set("cores", vm.MustCpu().MustTopology().MustCores())
+	d.Set("sockets", vm.MustCpu().MustTopology().MustSockets())
+	d.Set("threads", vm.MustCpu().MustTopology().MustThreads())
+	d.Set("authorized_ssh_key", vm.MustInitialization().MustAuthorizedSshKeys())
 
-	cluster, err := con.GetCluster(vm.Cluster.ID)
-	if err != nil {
-		d.SetId("")
-		return nil
+	// Use `conn.FollowLink` function to fetch cluster and template instance from a vm.
+	// See: https://github.com/imjoey/go-ovirt/blob/master/examples/follow_vm_links.go.
+	cluster, _ := conn.FollowLink(vm.MustCluster())
+	if cluster, ok := cluster.(*ovirtsdk4.Cluster); ok {
+		d.Set("cluster", cluster.MustName())
 	}
-	d.Set("cluster", cluster.Name)
+	template, _ := conn.FollowLink(vm.MustTemplate())
+	if template, ok := template.(*ovirtsdk4.Template); ok {
+		d.Set("template", template.MustName())
+	}
 
-	template, err := con.GetTemplate(vm.Template.ID)
-	if err != nil {
-		d.SetId("")
-		return nil
-	}
-	d.Set("template", template.Name)
-	d.Set("cores", vm.CPU.Topology.Cores)
-	d.Set("sockets", vm.CPU.Topology.Sockets)
-	d.Set("threads", vm.CPU.Topology.Threads)
-	d.Set("authorized_ssh_key", vm.Initialization.AuthorizedSSHKeys)
 	return nil
 }
 
 func resourceVMDelete(d *schema.ResourceData, meta interface{}) error {
-	con := meta.(*ovirtapi.Connection)
-	vm, err := con.GetVM(d.Id())
-	if err != nil {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	vmService := conn.SystemService().VmsService().VmService(d.Id())
+
+	return resource.Retry(3*time.Minute, func() *resource.RetryError {
+		getVMResp, err := vmService.Get().Send()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+
+		vm, ok := getVMResp.Vm()
+		if !ok {
+			d.SetId("")
+			return nil
+		}
+
+		if vm.MustStatus() != ovirtsdk4.VMSTATUS_DOWN {
+			_, err := vmService.Shutdown().Send()
+			if err != nil {
+				return resource.RetryableError(fmt.Errorf("Stop instance timeout and got an error: %v", err))
+			}
+		}
+		//
+		_, err = vmService.Remove().
+			DetachOnly(true). // DetachOnly indicates without removing disks attachments
+			Send()
+		if err != nil {
+			return resource.RetryableError(fmt.Errorf("Delete instalce timeout and got an error: %v", err))
+		}
+
 		return nil
-	}
-	if vm.Status != "down" {
-		vm.Stop("false")
-	}
-	for vm.Status != "down" {
-		time.Sleep(time.Second)
-		vm.Update()
-	}
-	return vm.Delete()
+
+	})
 }


### PR DESCRIPTION
This pr is for implementing the new `ovirt_datacenters` data source. We could get a list of `datacenter` instances by the `name` argument. Currently the returned attributes includes only the `id`, `stats`, `local` and `quota_mode`.